### PR TITLE
docs: populate .ai_state.md from repo state (was blank template)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,19 +1,21 @@
-# Project Objective: [Global Goal]
-
-<!-- Replace the bracket above with the current high-level goal for this session. -->
+# Project Objective: Stabilize and modernize the CDSL build-meta tooling in [ARCHITECTURE_REVIEW.md](ARCHITECTURE_REVIEW.md) via a non-destructive, human-gated cleanup taxonomy.
 
 ## ➡️ Next Steps (Queue)
 
-- [ ] (none queued yet)
+- [ ] MG: review [docs/cleanup/taxonomy_summary.md](docs/cleanup/taxonomy_summary.md) § Human Approval Queue (6 priority groups — transliteration consolidation, `updateByLine.py` copies, Python-3-failing scripts, `issues/issue445/` API prototype, generated reports, download/setup hardening) and fill `human_decision` in [docs/cleanup/taxonomy_proposals.csv](docs/cleanup/taxonomy_proposals.csv) (0/464 rows decided as of 07-07-2026) — nothing moves/deletes until this is filled.
+- [ ] Once a first batch of `human_decision` rows lands, open the corresponding cleanup issues per [docs/cleanup/cleanup_issue_backlog.md](docs/cleanup/cleanup_issue_backlog.md) — do not move files directly from the proposal.
+- [ ] ARCHITECTURE_REVIEW.md § Suggested Near-Term Backlog (agent-doable once taxonomy decisions unblock scope): script inventory table, `pyproject.toml`/`requirements.txt`, `tests/fixtures/mini_dict.txt` + tests for `updateByLine`/`xmltag`/`eascii`, fix `iast/transcoder.py` default XML lookup + remove duplicate `stardict/transcoder.py`, decide `stardict/make_babylon.py` fate, CI for Python-3 syntax+tests, shared `cologne_tools` module.
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- [ ] (no active task)
+- [ ] `README.md` has an uncommitted rewrite (dated header + pointers to the cleanup-taxonomy docs) sitting in the working tree, not yet committed — left as-is by `/gtd-sync` (07-07-2026); a human or the session that authored it should commit or discard it.
 
 ## 🧠 Dev Notes & Hypotheses
 
-<!-- Persistent bugs, architectural pivots, things future-you needs to know. Keep dated. -->
+- 07-07-2026: This file was an untouched blank template despite the repo having active work (`ARCHITECTURE_REVIEW.md` committed 04-07-2026, cleanup taxonomy docs already committed) — flagged by `/gtd-sync` Session 18 and filled in this pass. Populated from `ARCHITECTURE_REVIEW.md` § Roadmap/Backlog and `docs/cleanup/taxonomy_summary.md`, not from any conversation (no prior session narrative existed to recover).
 
 ## ✅ Completed (Recent only)
 
-<!-- Move items here as they're checked off. Trim aggressively — only the recent few. -->
+- [x] Cleanup taxonomy classification of all 464 repo files (`docs/cleanup/taxonomy_proposals.csv` + schema + summary + issue backlog) — proposal-only, awaiting MG's `human_decision` pass above.
+- [x] Architecture review + 5-phase modernization roadmap (`ARCHITECTURE_REVIEW.md`).
+- [x] Org-baseline hygiene: CI, CodeQL, pre-commit, dependabot, issue/PR templates, LICENSE, CONTRIBUTING.md, severity colour-dots on findings.


### PR DESCRIPTION
## Summary
- `.ai_state.md` had sat as the untouched blank scaffold since repo creation despite committed cleanup-taxonomy and architecture-review work already in the tree — flagged by Uprava `/gtd-sync` Session 18 (07-07-2026).
- Backfilled Queue/WIP/Notes from `ARCHITECTURE_REVIEW.md` and `docs/cleanup/taxonomy_summary.md` so the journal reflects the real outstanding work (mainly: the 464-row cleanup taxonomy CSV awaiting a human `human_decision` pass).

## Test plan
- [x] Docs-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)