### PR TITLE
docs(README): refresh stale status claims (H548)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # COLOGNE
 
-_Created: 14-01-2014 · Last updated: 05-07-2026_
+_Created: 14-01-2014 · Last updated: 11-07-2026_
 
 The Cologne Digital Sanskrit Dictionaries (CDSL) project has been accumulating
 build tooling, one-off scripts, generated reports, and issue-tracked
@@ -8,11 +8,10 @@ proposals since 2014 — long enough that nobody can say offhand which files
 are load-bearing infrastructure, which are dead prototypes, and which are
 stale reports nobody regenerates anymore. **COLOGNE is the project's
 build-meta repository**: it holds the cross-cutting tooling, architecture
-review, and (as of this pass) a non-destructive **cleanup taxonomy** that
-classifies every file in the repo — active tooling vs. generated report vs.
-archival issue-work vs. prototype vs. legacy — so a maintainer can approve,
-override, defer, or ignore each classification before anything gets moved or
-deleted.
+review, and a non-destructive **cleanup taxonomy** that classifies every file
+in the repo — active tooling vs. generated report vs. archival issue-work vs.
+prototype vs. legacy — so a maintainer can approve, override, defer, or ignore
+each classification before anything gets moved or deleted.
 
 Nothing is auto-deleted by this workflow. The taxonomy proposer only reads
 the tree and writes a CSV with `human_decision` left blank; a human (or an
@@ -20,16 +19,17 @@ agent under his instruction) fills that column before any cleanup PR happens.
 
 ## Cleanup planning
 
-- [ARCHITECTURE_REVIEW.md](ARCHITECTURE_REVIEW.md) — architecture review and roadmap
-- [docs/cleanup/taxonomy_schema.md](docs/cleanup/taxonomy_schema.md) — the classification schema
-- [docs/cleanup/taxonomy_summary.md](docs/cleanup/taxonomy_summary.md) — summary of proposals
-- [docs/cleanup/taxonomy_proposals.csv](docs/cleanup/taxonomy_proposals.csv) — per-file approval CSV
-- [docs/cleanup/cleanup_issue_backlog.md](docs/cleanup/cleanup_issue_backlog.md) — proposed cleanup issue backlog
+- [ARCHITECTURE_REVIEW.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/ARCHITECTURE_REVIEW.md) — architecture review and roadmap
+- [docs/cleanup/taxonomy_schema.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/docs/cleanup/taxonomy_schema.md) — the classification schema
+- [docs/cleanup/taxonomy_summary.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/docs/cleanup/taxonomy_summary.md) — summary of proposals
+- [docs/cleanup/taxonomy_proposals.csv](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/docs/cleanup/taxonomy_proposals.csv) — per-file approval CSV
+- [docs/cleanup/cleanup_issue_backlog.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/docs/cleanup/cleanup_issue_backlog.md) — proposed cleanup issue backlog
 
 ## Usage example — executed, real output
 
 Regenerating the taxonomy proposal is a single command, run for real against
-this repo's current tree while writing this README:
+this repo's current tree while writing this README
+([tools/propose_cleanup_taxonomy.py](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/tools/propose_cleanup_taxonomy.py)):
 
 ```bash
 python tools/propose_cleanup_taxonomy.py
@@ -45,33 +45,49 @@ Wrote 480 proposals to C:\Users\user\Documents\GitHub\COLOGNE\docs\cleanup
 - C:\Users\user\Documents\GitHub\COLOGNE\docs\cleanup\cleanup_issue_backlog.md
 ```
 
-480 files classified in one pass. The generated CSV leaves `human_decision`
-and `human_notes` blank so a maintainer can approve, override, defer, or
-ignore each proposed classification — this verification run's output was
-discarded (`git checkout`) afterward, so writing this README would not
-silently alter the repo's tracked cleanup state as a side effect.
+The generated CSV holds one classified row per scanned file (464 data rows in
+the current tree) and leaves `human_decision` and `human_notes` blank so a
+maintainer can approve, override, defer, or ignore each proposed
+classification — this verification run's output was discarded (`git checkout`)
+afterward, so writing this README would not silently alter the repo's tracked
+cleanup state as a side effect.
 
 ## Issues overview
 
-**Total**: 100 | **Open**: 71 | **Closed**: 29
+As of 11-07-2026 (live counts via the GitHub API):
 
-| Milestone | Open | Closed | Total |
-|---|---|---|---|
-| Unassigned | 71 | 29 | 100 |
+| State | Issues |
+|---|---|
+| Open | 199 |
+| Closed | 259 |
+| Total | 458 |
 
-By type: enhancement 67 · question 14 · bug 8 · performance 1.
-By severity: minor 59 · trivial 21.
+The full, always-current list is on the
+[issue tracker](https://github.com/sanskrit-lexicon/COLOGNE/issues). Per-label
+and per-milestone breakdowns are intentionally not hardcoded here — they drift
+faster than a README can be maintained; filter the live tracker instead.
 
 ## GitHub issue conventions
 
-Follows the [Cologne tooling-repo taxonomy](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/runbook/cologne-tooling-runbook.md):
+This build-meta repo follows the
+[Cologne tooling-repo taxonomy](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/runbook/cologne-tooling-runbook.md)
+for new issues (type + severity + milestone labels). Some older issues still
+carry legacy dictionary-style labels (`link-target`, `markup`, `scan-quality`,
+`text-correction`, …) from before this repo was recategorized; those are
+migrated opportunistically rather than in a bulk relabel. The org-level
+[Tooling Roadmap](https://github.com/orgs/sanskrit-lexicon/projects/9) project
+tracks tool work across all repositories.
 
-- **9 type labels**: bug, feature, enhancement, performance, tech-debt, security, documentation, infrastructure, question
-- **4 severity levels**: trivial, minor, major, critical
-- **5 milestones**: API Stability, User Experience, Data Quality, Developer Experience, Community
-- **Org Project**: [Tooling Roadmap](https://github.com/orgs/sanskrit-lexicon/projects/9)
+See [CLAUDE.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/CLAUDE.md)
+for the full label and milestone definitions.
 
-See [CLAUDE.md](CLAUDE.md) for full definitions.
+## Correcting dictionary source text
+
+COLOGNE holds build tooling, not the dictionary source files themselves.
+Corrections to the actual dictionary text (in `csl-orig`) are never made by
+hand-editing source — they go through the change-file workflow documented
+canonically in
+[csl-corrections/docs/correction-workflow.md](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md).
 
 ---
 


### PR DESCRIPTION
Part of **H548** (README audit+refactor across Cologne dictionary repos): https://github.com/gasyoun/Uprava/blob/main/handoffs/H548-Opus_Uprava_readme-refresh-dict-repos_10.07.26.md

## What was wrong
- **Issue counts badly stale**: README claimed 100 total (71 open / 29 closed). Live GitHub API as of 11-07-2026: **199 open / 259 closed (458 total)**.
- **Fabricated milestone/type/severity breakdowns**: the milestone table ("Unassigned 71/29/100"), the "By type: enhancement 67 · question 14 · bug 8 · performance 1" line, and the "By severity: minor 59 · trivial 21" line did not match reality. The repo's actual milestones are the dictionary-set (`Dictionary to Book`, `Digitization Quality`, `Structured Data`, `Major Enhancements`, plus date-based ones), not the 5 tooling milestones named. Actual labels are a dictionary/tooling mix, not the clean 9-type taxonomy. These hardcoded breakdowns are removed in favor of a live-tracker link.
- **Relative links** throughout — converted to full `github.com/.../blob/main/...` URLs per org convention.

## What was fixed
- Accurate top-line issue counts + link to the live tracker.
- Full blob URLs for every internal path.
- Added a canonical link to [csl-corrections/docs/correction-workflow.md](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md).
- Reconciled the taxonomy prose (464 CSV data rows) while keeping the tool's genuine `480 proposals` stdout in the real-output block.
- Bumped `Last updated` to 11-07-2026; creation date (14-01-2014) preserved from git history.

No divergence action needed: the local `docs/ai-state-fill` branch was already merged as #465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)