### PR TITLE
docs: record H506 manual completion in .ai_state.md

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -16,6 +16,7 @@
 
 ## ✅ Completed (Recent only)
 
+- [x] 11-07-2026 (H506, Fable 5 `claude-fable-5`): operator manual [docs/TOOLING_MANUAL.md](docs/TOOLING_MANUAL.md) + [docs/TOOLING_MANUAL.meta.md](docs/TOOLING_MANUAL.meta.md) covering all 14 tooling directories, linked from README — [PR #468](https://github.com/sanskrit-lexicon/COLOGNE/pull/468) merged.
 - [x] Cleanup taxonomy classification of all 464 repo files (`docs/cleanup/taxonomy_proposals.csv` + schema + summary + issue backlog) — proposal-only, awaiting MG's `human_decision` pass above.
 - [x] Architecture review + 5-phase modernization roadmap (`ARCHITECTURE_REVIEW.md`).
 - [x] Org-baseline hygiene: CI, CodeQL, pre-commit, dependabot, issue/PR templates, LICENSE, CONTRIBUTING.md, severity colour-dots on findings.


### PR DESCRIPTION
Journal upkeep after [PR #468](https://github.com/sanskrit-lexicon/COLOGNE/pull/468) (H506 operator manual): one completed-entry line in [.ai_state.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/.ai_state.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)