### PR TITLE
docs: metadoc template v2 backfill (H663)

### DIFF
--- a/docs/TOOLING_MANUAL.meta.md
+++ b/docs/TOOLING_MANUAL.meta.md
@@ -51,6 +51,76 @@ plus four parallel directory-exploration passes over all 14 tooling directories
 - Load-bearing verdicts mirror the cleanup taxonomy as of 464-row generation
   (0 rows human-decided); they may shift once decisions land.
 
+## Intended use / known misuse
+
+**For:** onboarding a new operator/contributor onto every *live, runnable* workflow in
+COLOGNE — which command to type, from which directory, against which sibling-repo
+layout — without reading the source of `tools/`, `enhancements/code/`, `eascii/`,
+`xmltag/`, `iast/`, `makemd/`, `localinstall/`, or `stardict/` first. It is also the
+correct first stop for diagnosing a failure via the Symptom → cause → cure table, and
+for the new-dictionary-onboarding map (which still defers to
+[readme_new_dict_addition.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/readme_new_dict_addition.md)
+for execution detail).
+
+**Known/likely misuse:**
+
+- **Treating it as a source-text correction guide.** It explicitly documents only the
+  local engine (`updateByLine.py`); the canonical correction workflow is
+  [csl-corrections/docs/correction-workflow.md](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md).
+  Applying corrections from this manual alone skips the snapshot/promote/audit stages.
+- **Running commands verbatim without the `cologne/` umbrella sibling layout.** Nearly
+  every `redo_*`/`download*`/`install_local.sh` command assumes COLOGNE sits inside a
+  `cologne/` directory next to `csl-orig` (and, for `iast/`, `csl-apidev` +
+  `csl-websanlexicon`) — a bare GitHub checkout will fail on input paths, and that
+  failure is layout, not a tool bug, per the manual's own Environment section.
+  Misreading such a failure as "the script is broken" is the most likely error.
+- **Reading transcoder silence as success.** Both `iast/transcoder.py` and its
+  divergent copy `stardict/transcoder.py` return input **unchanged instead of
+  erroring** when they cannot find their FSM XML tables (wrong CWD, or a missing
+  `stardict/data/transcoder/`) — the manual flags this as a P1 silent-passthrough
+  defect. A `GOOD`/`WARNING` console line from `slp1_iast.py`, not silence, is the
+  real success signal; treating "no error" as "it worked" is the documented trap.
+- **Editing `iast/slp1_roman.xml` or `roman_slp1.xml` without running `install_local.sh`
+  and pushing the two PHP-repo consumers.** The three copies are hand-synced; editing
+  only the COLOGNE copy leaves the live site on stale tables.
+- **Treating the cleanup-taxonomy CSV as an execution order.** `tools/propose_cleanup_taxonomy.py`
+  output is proposal-only (`human_decision` blank for all 464 rows as of 11-07-2026);
+  moving or deleting a file on the strength of the CSV alone, before a human fills the
+  decision column and an issue is opened from the backlog, contradicts the documented
+  human loop.
+- **Running `stardict/` or `enhancements/issue10/` as templates for new work.** Both are
+  flagged 🔴 legacy Python-2-only in the cheat-sheet; the manual documents them for
+  operability of existing exports, not as a pattern to extend.
+
+## Maintenance & sunset plan
+
+**Owner:** the COLOGNE repo itself — specifically whoever next touches the directories
+this manual documents (14 tooling directories) or the cleanup-taxonomy pipeline in
+`tools/`. There is no dedicated bot or CI job that keeps this manual current; it is
+maintained the same way it was written — an agent session re-reading source + running
+`tools/propose_cleanup_taxonomy.py` and updating the affected walkthrough section in
+the same PR as the underlying change (see backlog item 3 above).
+
+**Sunset triggers:**
+
+- If the taxonomy `human_decision` pass lands and files referenced here move or are
+  retired (backlog item 3), the walkthrough sections for those directories need a
+  same-PR update, not a rewrite from scratch.
+- If `stardict/` is ported to Python 3 or retired (Human Approval Queue item, backlog
+  item 4), its walkthrough section and the cheat-sheet status row are the ones to
+  rewrite or drop.
+- **What "archived/ended" looks like:** this manual is retired only if COLOGNE's
+  tooling surface is itself consolidated or the repo is merged/retired at the org
+  level — there is no independent expiry date. Until then it stays `active` and is
+  expected to be edited in place rather than superseded by a new document.
+
+## Deprecation status
+
+`active` — authored same-day (11-07-2026) as its subject document, with backlog item 1
+("commands not yet run live in a full CDSL umbrella checkout") still open. No successor
+document exists and no evidence surfaced during this backfill that the manual's
+commands or directory map are stale.
+
 ## Related documents
 
 - [README.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/README.md) — repo intro + taxonomy entry point
@@ -63,5 +133,6 @@ plus four parallel directory-exploration passes over all 14 tooling directories
 | Date | Change | By |
 |---|---|---|
 | 11-07-2026 | Initial version (H506): cheat-sheet, data-flow, 14 directory walkthroughs, new-dict flow, load-bearing verdicts, symptom table, glossary, maintainer appendix | Fable 5 (`claude-fable-5`) |
+| 11-07-2026 | template v2 backfill (H663) | Sonnet 5 (`claude-sonnet-5`) |
 
 _Dr. Mārcis Gasūns_


### PR DESCRIPTION
## Summary
- Adds three new template-v2 metadoc sections to docs/TOOLING_MANUAL.meta.md: Intended use / known misuse, Maintenance & sunset plan, Deprecation status — inserted between Known limitations and Related documents
- Content is derived from reading docs/TOOLING_MANUAL.md itself (traps, ownership boundaries, backlog status), not boilerplate
- Deprecation status recorded as `active` (backlog item 1 still open, no successor doc, manual authored same-day as subject)
- Appended revision-history row and bumped Last updated to 11-07-2026

## Test plan
- [x] Reviewed rendered markdown for section placement and link correctness (full https blob URLs used for the one new link)
- [x] No merge — left open for a human to review

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>