### PR TITLE
docs: TOOLING_MANUAL estate refresh — fact-check recounts, executed worked examples, LAST_VERIFIED metadoc block (H1245)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -8,7 +8,7 @@
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- [ ] `README.md` has an uncommitted rewrite (dated header + pointers to the cleanup-taxonomy docs) sitting in the working tree, not yet committed — left as-is by `/gtd-sync` (07-07-2026); a human or the session that authored it should commit or discard it.
+- (none — the 07-07-2026 note about an uncommitted `README.md` rewrite was stale: that rewrite landed 11-07-2026 and the tree was verified clean on 18-07-2026, H1245.)
 
 ## 🧠 Dev Notes & Hypotheses
 
@@ -16,6 +16,7 @@
 
 ## ✅ Completed (Recent only)
 
+- [x] 18-07-2026 (H1245, Fable 5 `claude-fable-5`): estate refresh of [docs/TOOLING_MANUAL.md](docs/TOOLING_MANUAL.md) — fact-check recounts, executed worked example for `updateByLine.py`, engine-verification pattern, `LAST_VERIFIED` block in the metadoc.
 - [x] 11-07-2026 (H506, Fable 5 `claude-fable-5`): operator manual [docs/TOOLING_MANUAL.md](docs/TOOLING_MANUAL.md) + [docs/TOOLING_MANUAL.meta.md](docs/TOOLING_MANUAL.meta.md) covering all 14 tooling directories, linked from README — [PR #468](https://github.com/sanskrit-lexicon/COLOGNE/pull/468) merged.
 - [x] Cleanup taxonomy classification of all 464 repo files (`docs/cleanup/taxonomy_proposals.csv` + schema + summary + issue backlog) — proposal-only, awaiting MG's `human_decision` pass above.
 - [x] Architecture review + 5-phase modernization roadmap (`ARCHITECTURE_REVIEW.md`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to the COLOGNE build-meta repository are documented here.
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This repo has no
+version tags to date; entries accumulate under Unreleased until the maintainers
+choose to cut a first release.
+
+## [Unreleased]
+
+### Changed
+
+- `docs/TOOLING_MANUAL.md` estate refresh (H1245, 18-07-2026): fact-check recounts
+  against the live tree (`issues/` 265 files not 270; `xmltag/catall.sh` 36 codes
+  not 34, the 8 missing codes named; `stardict/redo.sh` 36 not 37; eascii output
+  format), an executed `updateByLine.py` worked example (apply + stop-on-mismatch),
+  an engine-verification pattern for checkouts without the `cologne/` umbrella
+  layout, and a `DeprecationWarning` symptom row. Companion
+  `docs/TOOLING_MANUAL.meta.md` gains a `LAST_VERIFIED` verification block
+  (6 commands spot-run), a reconciled backlog, and a consolidation verdict.

--- a/docs/TOOLING_MANUAL.md
+++ b/docs/TOOLING_MANUAL.md
@@ -121,6 +121,17 @@ PHP + `mod_rewrite` (localinstall serving), XAMPP + `mako` + `sqlite3` + `zip`
 `UnicodeEncodeError: 'charmap' codec`. Do not remove them; add them to any new script
 that prints Sanskrit.
 
+**Verifying the engines without the umbrella layout.** Only the `redo_*.sh` /
+`install_local.sh` *drivers* hardcode the `../../../cologne/…` sibling paths; the
+Python engines underneath (`ea.py`, `xmltag.py`, `chgtag.py`, `updateByLine.py`) all
+take explicit input/output file arguments, so each can be exercised against **any**
+`csl-orig` checkout by passing paths directly. Done live 18-07-2026 from a bare
+GitHub layout (`csl-orig` cloned as a plain sibling): `python xmltag/xmltag.py
+../csl-orig/v02/mw/mw.txt out.txt` → `25 distinct tags written`; `python eascii/ea.py`
+on the same input → `230 extended ascii counts written`; `python xmltag/chgtag.py` on
+`gra.txt` → `380 instances written`. When a driver fails on paths, drop to the engine
+with explicit arguments before concluding anything is broken.
+
 ---
 
 ## Directory walkthroughs
@@ -186,6 +197,38 @@ This is the shared core of the Cologne correction machinery.
   validate → audit → commit → refresh) is canonical in
   [csl-corrections/docs/correction-workflow.md](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md);
   do not re-derive it from here.
+
+  **Worked example (executed 18-07-2026, real output).** A minimal three-line
+  digitization and a one-transaction change-file:
+
+  ```
+  # old.txt                          # chg.txt
+  <L>1<pc>1,1<k1>a<k2>a              ; test change-file
+  {#a#} ¦ the first letter.          2 old {#a#} ¦ the first letter.
+  <LEND>                             2 new {#a#} ¦ the first letter of the alphabet.
+  ```
+
+  ```bash
+  $ python updateByLine.py old.txt chg.txt new.txt
+  3 lines read from old.txt
+  3 records written to new.txt
+  1 change transactions from chg.txt
+  1 of type new
+  ```
+
+  Line 2 of `new.txt` now reads `…the first letter of the alphabet.` Feeding the same
+  engine a change-file whose `old` line does not match stops the run exactly as
+  documented — no output file is completed:
+
+  ```
+  CHANGE ERROR #2: Old mismatch line 1 of bad.txt
+  Change record lnum = 2
+  b'Change old text:\nWRONG TEXT'
+  b'Change old input:\n{#a#} \xc2\xa6 the first letter.'
+  ```
+
+  (Under Python 3.13+ every run also prints a cosmetic `codecs.open() is deprecated`
+  `DeprecationWarning` — harmless, see the symptom table.)
 
 - [updateByLine_python2.py](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/enhancements/code/updateByLine_python2.py) —
   the Python-2 legacy twin. Do not use for new work.
@@ -553,6 +596,7 @@ The row-level source of truth for these calls is
 | Transcoded text comes back unchanged (SLP1 in, SLP1 out), no error | `transcoder.py` couldn't find its FSM XML (wrong CWD, or `stardict/data/transcoder/` absent) and **silently passes input through** | Run from `iast/`; for stardict, create `data/transcoder/` and copy the tables in; spot-check output for Devanagari |
 | `SyntaxError` on `print` or `xrange` | You ran a Python-2-only script (`stardict/make_babylon.py`, `issue10/*.py`, `updateByLine_python2.py`) under Python 3 | Use a py2 interpreter, or use the py3 twin (`updateByLine.py`); see the [interpreter table](#environment--prerequisites) |
 | `UnicodeEncodeError: 'charmap' codec` printing Sanskrit on Windows | git-bash console encoding; the script lacks `sys.stdout.reconfigure(encoding='utf-8')` | Add the reconfigure line (present in all `eascii/` scripts as the model) |
+| `DeprecationWarning: codecs.open() is deprecated` spam on every run | Python 3.13+ deprecates `codecs.open`, which the older scripts (`updateByLine.py`, `ea.py`, `xmltag.py`, `chgtag.py`) still use | Cosmetic — output is unaffected (verified 18-07-2026 on Python 3.14.4). Silence with `python -W ignore::DeprecationWarning` if it obscures real output |
 | `redo_one.sh` / `redo_all.sh` can't find the input file | The `../../../cologne/csl-orig/...` sibling layout isn't in place | Recreate the umbrella layout (clone csl-orig under a shared `cologne/` parent) or edit the path; `eachanges-degree/` needs one *extra* `../` |
 | `make_babylon.py` dies with `IOError` on first write | `stardict/output/` does not exist in the repo | `mkdir output` first |
 | `make_md.py` raises `IndexError` immediately | No dictcode argument (bare `sys.argv[1]`) | `python3 make_md.py <dictcode>` |

--- a/docs/TOOLING_MANUAL.md
+++ b/docs/TOOLING_MANUAL.md
@@ -1,6 +1,6 @@
 # COLOGNE cross-cutting tooling — operator manual
 
-_Created: 11-07-2026 · Last updated: 11-07-2026_
+_Created: 11-07-2026 · Last updated: 18-07-2026_
 
 This is the operator manual for the [COLOGNE](https://github.com/sanskrit-lexicon/COLOGNE)
 build-meta repository of the Cologne Digital Sanskrit Lexicon (CDSL) project. The test
@@ -41,7 +41,7 @@ Each row links to its detailed section below. "Status" is the load-bearing verdi
 | [aws/](https://github.com/sanskrit-lexicon/COLOGNE/tree/main/aws) | S3 upload notes (2014) + bucket manifests | none — archival + inventories | 🟡 manifests useful |
 | [enhancements/autocomplete/](https://github.com/sanskrit-lexicon/COLOGNE/tree/main/enhancements/autocomplete) | headword autocomplete data generator | `python listsanhw1.py` | 🟡 data ships, script legacy |
 | [enhancements/issue10/](https://github.com/sanskrit-lexicon/COLOGNE/tree/main/enhancements/issue10) | spelling-suggestion prototype | `python2 suggest.py inputword` | 🔴 legacy Python 2 |
-| [issues/](https://github.com/sanskrit-lexicon/COLOGNE/tree/main/issues) | per-issue archival workspaces (270 files) | none — archival; exception: issue445 | ⚪ archival |
+| [issues/](https://github.com/sanskrit-lexicon/COLOGNE/tree/main/issues) | per-issue archival workspaces (265 files) | none — archival; exception: issue445 | ⚪ archival |
 | [xsswork/](https://github.com/sanskrit-lexicon/COLOGNE/tree/main/xsswork) | 2022 XSS-hardening notes | none — memo | ⚪ archival |
 | [misc/](https://github.com/sanskrit-lexicon/COLOGNE/tree/main/misc) | scholarly reference artifacts | none — reference | ⚪ archival |
 
@@ -149,12 +149,12 @@ It writes four files into
 [docs/cleanup/](https://github.com/sanskrit-lexicon/COLOGNE/tree/main/docs/cleanup):
 
 1. [taxonomy_schema.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/docs/cleanup/taxonomy_schema.md) — the label glossary;
-2. [taxonomy_proposals.csv](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/docs/cleanup/taxonomy_proposals.csv) — one row per file (464 rows currently), `human_decision`/`human_notes` left **blank**;
+2. [taxonomy_proposals.csv](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/docs/cleanup/taxonomy_proposals.csv) — one row per file (464 rows in the committed generation; a fresh verification run on 18-07-2026 classified 482 files, the tree having grown since), `human_decision`/`human_notes` left **blank**;
 3. [taxonomy_summary.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/docs/cleanup/taxonomy_summary.md) — totals + the 6-group Human Approval Queue;
 4. [cleanup_issue_backlog.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/docs/cleanup/cleanup_issue_backlog.md) — 9 pre-drafted cleanup issues.
 
 **The human loop:** a maintainer fills `human_decision` per row with `approve`,
-`override`, `defer`, or `ignore` (+ free-text `human_notes`). As of 11-07-2026, 0 of
+`override`, `defer`, or `ignore` (+ free-text `human_notes`). As of 18-07-2026, 0 of
 464 rows are decided; nothing may be moved or deleted before decisions land, and even
 then the change goes through issues opened from the backlog doc — never directly from
 the proposal.
@@ -219,7 +219,9 @@ python easummary.py ../../../cologne/csl-orig easummary        # cross-dict matr
 python easummary_meta.py ../../../cologne/csl-orig easummary_meta  # metaline-only
 ```
 
-Output lines look like `° (°) 55614 := DEGREE SIGN`. Scripts only count
+Output lines look like `° (°) 55614 := DEGREE SIGN` — the parenthesis holds the
+`\uNNNN` codepoint escape, not the character again (verified live 18-07-2026: a run
+against `mw` opens with `¦ (\u00a6) 282169 := BROKEN BAR`). Scripts only count
 characters **inside entries** (from the `<L>` metaline to `<LEND>`), deliberately
 excluding front matter. `easummary.py` splits Greek/Arabic/Cyrillic into separate
 TSVs; `easummary_meta.py` examines only the `<L>` metalines and does **not** separate
@@ -255,8 +257,9 @@ curly pseudo-tags `{#…#}` `{@…@}` `{%…%}` are deliberately out of scope. T
 is a line-based regex (`<(.*?)>`) — an approximate corpus scanner, not a validator.
 
 **Trap:** `redo_all.sh` and `catall.sh` iterate **different** dictionary-code lists
-(44 vs 34) — `catall.sh` concatenates fewer files than `redo_all.sh` generates. Check
-both lists before trusting `all_xmltags.txt` as complete.
+(44 vs 36, recounted 18-07-2026) — `catall.sh` concatenates fewer files than
+`redo_all.sh` generates (it lacks `ap`, `pd`, `pwkvn`, `lrv`, `abch`, `acph`, `acsj`,
+`fri`). Check both lists before trusting `all_xmltags.txt` as complete.
 
 ### iast/ — the transcoding source of truth
 
@@ -273,8 +276,11 @@ python slp1_iast.py slp1_roman.xml slp1_iast.txt
 
 Regenerates the human-readable table `slp1_iast.txt` and runs three consistency
 checks (IAST→SLP1 round-trip; SLP1 keysets match across the two XMLs; IAST keysets
-match), printing `GOOD` or `WARNING` per check. Run this after **any** edit to either
-XML.
+match). The round-trip check reports a problem count (`check1_invert. 0 slp1 iast
+inversion problems`); the two keyset checks print `GOOD` or `WARNING`. Run this after
+**any** edit to either XML. Verified live 18-07-2026: 84 mappings, all three checks
+clean, and the committed `slp1_iast.txt` matches the XMLs byte-for-byte (regeneration
+produced only line-ending churn).
 
 **Install to the live PHP repos (Windows XAMPP layout only):**
 
@@ -390,7 +396,7 @@ P1). If you must run it:
 mkdir -p output                                    # trap 1: output/ does not exist
 # trap 2: supply the transcoder FSM tables (see below) or output is silently wrong
 python2 make_babylon.py ../../Cologne_localcopy md # one dictionary
-sh redo.sh                                         # all 37 codes
+sh redo.sh                                         # all 36 codes
 ```
 
 Reads `<pathToDicts>/<id>/<id>xml/xml/<id>.xml` from a local mirror named
@@ -447,8 +453,9 @@ Python 3 — port-or-retire.
 
 One directory per GitHub issue (`407`, `issue422`…`issue445`), indexed by
 [issues/readme.txt](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/issues/readme.txt).
-Policy: **archival — preserve for provenance, never refactor** (270 files classified
-`archive-no-refactor`). Many scripts are byte-identical copies across issue dirs
+Policy: **archival — preserve for provenance, never refactor** (265 files in the
+directory; 248 classified `archive-no-refactor`, the 17 `issue445` prototype files
+`promote-or-sunset` — recounted from the CSV 18-07-2026). Many scripts are byte-identical copies across issue dirs
 (`issue422`–`issue432` are the same hwextra-Lbody conversion applied to ten
 dictionaries) — a bug fixed in one copy is NOT fixed in the others; the canonical
 version of anything reusable is `enhancements/code/`.

--- a/docs/TOOLING_MANUAL.md
+++ b/docs/TOOLING_MANUAL.md
@@ -99,9 +99,10 @@ what `install_local.sh` and the `../../../cologne/csl-orig/...` relative paths i
 | `iast/slp1_iast.py`, `iast/transcoder.py` | Python 2 or 3 | dual-version by design |
 | `makemd/make_md.py` | Python 3 | needs pip package `indic_transliteration` |
 | `enhancements/code/updateByLine.py` | Python 3 | (`updateByLine_python2.py` is the py2 twin) |
-| `enhancements/code/xmlvalidate.py` | Python 2.7 + `lxml` | Windows stand-in for `xmllint` |
-| `stardict/make_babylon.py`, `stardict/transcoder.py` | **Python 2 only** | `print` statements, `xrange` — SyntaxError under py3 |
-| `enhancements/issue10/*.py` | **Python 2 only** | same |
+| `enhancements/code/xmlvalidate.py` | Python 3 + `lxml` | its own docstring says `python3`; the "Python 2.7" in `enhancements/code/readme.md` is stale |
+| `stardict/make_babylon.py` | **Python 2 only** | `print` statement (line 23) — SyntaxError under py3 |
+| `stardict/transcoder.py` | Python 2 (runtime) | parses under py3 but dies at runtime on `xrange` (lines 169, 340) — a `NameError`, not a SyntaxError |
+| `enhancements/issue10/suggest.py`, `levenshtein.py` | **Python 2 only** | SyntaxError under py3 (`hw1list.py` in the same dir is py3-clean) |
 | `aws/awsintro.txt` procedure | Python 2.6/2.7 + `awscli` | 2014 host setup, archival |
 
 There is no `requirements.txt`/`pyproject.toml` yet (a known
@@ -234,7 +235,8 @@ This is the shared core of the Cologne correction machinery.
   the Python-2 legacy twin. Do not use for new work.
 - [xmlvalidate.py](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/enhancements/code/xmlvalidate.py) —
   `python xmlvalidate.py file.xml file.dtd` — DTD validation on Windows where
-  `xmllint` is unavailable (Python 2.7 + `lxml`).
+  `xmllint` is unavailable (Python 3 + `lxml`; the script's own usage line says
+  `python3`, and the "Python 2.7" note in `readme.md` is stale).
 - [dictionary_init.sh](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/enhancements/code/dictionary_init.sh) —
   `sh dictionary_init.sh mw` — downloads a per-dictionary working environment
   (orig / pywork / web) from the project's AWS blobs into a `cologne/` dir under the
@@ -262,9 +264,9 @@ python easummary.py ../../../cologne/csl-orig easummary        # cross-dict matr
 python easummary_meta.py ../../../cologne/csl-orig easummary_meta  # metaline-only
 ```
 
-Output lines look like `° (°) 55614 := DEGREE SIGN` — the parenthesis holds the
-`\uNNNN` codepoint escape, not the character again (verified live 18-07-2026: a run
-against `mw` opens with `¦ (\u00a6) 282169 := BROKEN BAR`). Scripts only count
+Output lines look like `° (\u00b0) 55614 := DEGREE SIGN` — the parenthesis holds
+the `\uNNNN` codepoint escape, not the character again (verified live 18-07-2026: a
+run against `mw` opens with `¦ (\u00a6) 282169 := BROKEN BAR`). Scripts only count
 characters **inside entries** (from the `<L>` metaline to `<LEND>`), deliberately
 excluding front matter. `easummary.py` splits Greek/Arabic/Cyrillic into separate
 TSVs; `easummary_meta.py` examines only the `<L>` metalines and does **not** separate
@@ -306,10 +308,12 @@ is a line-based regex (`<(.*?)>`) — an approximate corpus scanner, not a valid
 
 ### iast/ — the transcoding source of truth
 
-**What it is:** `slp1_roman.xml` and `roman_slp1.xml` here are, per
-[iast/readme.txt](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/iast/readme.txt),
-**the source of truth for the transliteration tables the live CDSL website uses**.
-Editing them changes how the production displays transcode Sanskrit.
+**What it is:**
+[iast/readme.txt](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/iast/readme.txt)
+names `slp1_roman.xml` as **the source of truth for the transliteration tables the
+live CDSL website uses**; `roman_slp1.xml` is its companion inverse, kept consistent
+by the checks below and installed alongside it. Editing either changes how the
+production displays transcode Sanskrit.
 
 **Run (from `iast/` — the CWD matters, see trap):**
 
@@ -478,7 +482,8 @@ end in unresolved "Questions" sections — the spec was never finalized.
 is Jim Funderburk's December-2014 log of pushing the scans to `s3://sanskrit-lexicon/`
 (Python 2.6 virtualenv, `aws s3 cp … --acl public-read --recursive`) — archival; do
 not imitate the setup. The durable value is the **manifests**: `aws_scans_list.txt`
-(47,962 scan PDFs), `aws_scans_summary.txt` (per-dictionary PDF filename formats),
+(47,962 scan objects — ~43,161 PDFs plus 3,418 `.png` and 1,383 `.jpg` images),
+`aws_scans_summary.txt` (per-dictionary PDF filename formats),
 plus blob/web1 zip inventories with sizes — the index of what lives in the bucket
 (objects like `https://s3.amazonaws.com/sanskrit-lexicon/scans/ACC/pg1_002.pdf`),
 last refreshed 2023. One operational fact worth keeping: objects uploaded without
@@ -497,8 +502,10 @@ Python 3 — port-or-retire.
 One directory per GitHub issue (`407`, `issue422`…`issue445`), indexed by
 [issues/readme.txt](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/issues/readme.txt).
 Policy: **archival — preserve for provenance, never refactor** (265 files in the
-directory; 248 classified `archive-no-refactor`, the 17 `issue445` prototype files
-`promote-or-sunset` — recounted from the CSV 18-07-2026). Many scripts are byte-identical copies across issue dirs
+directory; 248 classified `archive-no-refactor` and 17 `promote-or-sunset` —
+recounted from the CSV 18-07-2026. The 17 span **four** issue dirs, not just the
+prototype: `issue441` 5 · `issue442` 5 · `issue443` 2 · `issue445` 5 — all await
+the same promote-or-sunset decision). Many scripts are byte-identical copies across issue dirs
 (`issue422`–`issue432` are the same hwextra-Lbody conversion applied to ten
 dictionaries) — a bug fixed in one copy is NOT fixed in the others; the canonical
 version of anything reusable is `enhancements/code/`.
@@ -676,8 +683,13 @@ fixing several is gated on the taxonomy `human_decision` pass):
 `ruff` lint (Python-2 dirs excluded via
 [ruff.toml](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/ruff.toml)),
 change-file format validation (`changes*.txt` must follow the `NNN` +
-`old`/`new`/`ins`/`del` grammar), change-file UTF-8 validation, YAML lint. CodeQL
-(Python) runs on PRs and weekly. Dependabot PRs auto-merge once checks pass.
+`old`/`new`/`ins`/`del` grammar), change-file UTF-8 validation, YAML lint. Dependabot
+PRs auto-merge once checks pass. CodeQL (Python) effectively runs **weekly-cron only**:
+its push/PR triggers in
+[codeql.yml](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/.github/workflows/codeql.yml)
+target `master`, but the default branch is `main`, so PR-time CodeQL never fires —
+a known trigger-config bug (flagged 18-07-2026, H1245; fix is queued as an issue,
+deliberately not part of a docs-only pass).
 
 **Companion metadoc:** improvement backlog, provenance, and revision history for this
 manual live in

--- a/docs/TOOLING_MANUAL.meta.md
+++ b/docs/TOOLING_MANUAL.meta.md
@@ -165,6 +165,6 @@ commands or directory map are stale.
 |---|---|---|
 | 11-07-2026 | Initial version (H506): cheat-sheet, data-flow, 14 directory walkthroughs, new-dict flow, load-bearing verdicts, symptom table, glossary, maintainer appendix | Fable 5 (`claude-fable-5`) |
 | 11-07-2026 | template v2 backfill (H663) | Sonnet 5 (`claude-sonnet-5`) |
-| 18-07-2026 | H1245 estate refresh: fact-check recounts (issues/ 265 not 270; catall 36 not 34; stardict redo 36 not 37; eascii output format), executed worked example for `updateByLine.py`, engine-verification pattern + DeprecationWarning symptom row, `LAST_VERIFIED` block + backlog reconcile, consolidation verdict (no fold) | Fable 5 (`claude-fable-5`) |
+| 18-07-2026 | H1245 estate refresh: fact-check recounts (issues/ 265 not 270; catall 36 not 34; stardict redo 36 not 37; eascii output format), executed worked example for `updateByLine.py`, engine-verification pattern + DeprecationWarning symptom row, `LAST_VERIFIED` block + backlog reconcile, consolidation verdict (no fold). Adversarial fact-check pass (8 findings, all fixed): promote-or-sunset spans 4 issue dirs; CodeQL is weekly-cron-only (`master` triggers vs `main` default branch — bug flagged, not fixed here); `stardict/transcoder.py` fails at runtime not parse; `issue10/hw1list.py` is py3-clean; `xmlvalidate.py` is py3; aws manifest is objects not all PDFs; iast readme names only `slp1_roman.xml` | Fable 5 (`claude-fable-5`) |
 
 _Dr. Mārcis Gasūns_

--- a/docs/TOOLING_MANUAL.meta.md
+++ b/docs/TOOLING_MANUAL.meta.md
@@ -1,6 +1,6 @@
 # TOOLING_MANUAL.md — metadoc
 
-_Created: 11-07-2026 · Last updated: 11-07-2026_
+_Created: 11-07-2026 · Last updated: 18-07-2026_
 
 Companion record for
 [docs/TOOLING_MANUAL.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/docs/TOOLING_MANUAL.md).
@@ -31,21 +31,52 @@ Source evidence: repo docs
 plus four parallel directory-exploration passes over all 14 tooling directories
 (same model tier).
 
+## Verification
+
+```
+LAST_VERIFIED: 18-07-2026
+VERIFIED_BY: Fable 5 (claude-fable-5), H1245
+COMMANDS_SPOT_RUN: 6
+```
+
+Spot-run 18-07-2026: `tools/propose_cleanup_taxonomy.py` (482 proposals on the grown
+tree; diff discarded per the manual's own trap note), `iast/slp1_iast.py` (84 mappings,
+3 checks clean, committed table in sync), `updateByLine.py` (fixture apply + the
+stop-on-mismatch path), `xmltag/xmltag.py`, `eascii/ea.py`, `xmltag/chgtag.py` (each
+against a plain `csl-orig` sibling with explicit paths). **Not** spot-run: the
+umbrella-layout drivers (`redo_*.sh`, `install_local.sh`, `download2*.sh` — layout and
+production-server dependencies absent) and every Python-2-only script (no `python2`
+on the verifying host); the manual marks these inline.
+
 ## Ranked improvement backlog
 
 | # | Item | Status |
 |---|---|---|
-| 1 | Verify each documented command by executing it in a full CDSL umbrella checkout (this manual is source-derived; commands were not all run live) | open |
-| 2 | Add a worked end-to-end example with real output for one census run (`sh redo_one.sh mw`) once a csl-orig sibling is available | open |
-| 3 | When the taxonomy `human_decision` pass lands and files move, update the walkthrough paths and the load-bearing table in the same PR | open |
+| 1 | Verify each documented command by executing it in a full CDSL umbrella checkout (this manual is source-derived; commands were not all run live) | **narrowed 18-07-2026 (H1245):** all path-parameterized engines + governance/iast commands now executed live (see Verification); still open only for the umbrella-layout drivers and py2-only scripts |
+| 2 | Add a worked end-to-end example with real output for one census run (`sh redo_one.sh mw`) once a csl-orig sibling is available | **done 18-07-2026 (H1245)** — worked example landed for `updateByLine.py` (apply + mismatch), and census engines run live against a plain csl-orig sibling with real output quoted; a driver-level `redo_one.sh` run still needs the umbrella layout (folded into item 1) |
+| 3 | When the taxonomy `human_decision` pass lands and files move, update the walkthrough paths and the load-bearing table in the same PR | open — still 0/464 rows decided as of 18-07-2026 |
 | 4 | If `stardict/` is ported to Python 3 or retired (Human Approval Queue #3), rewrite or drop its section | open |
-| 5 | Cross-link from the org manuals index / FEATURES_INDEX if a docs census consumes this | open |
+| 5 | Cross-link from the org manuals index / FEATURES_INDEX if a docs census consumes this | **done 18-07-2026** — tracked in [Uprava/METADOCS_INDEX.md](https://github.com/gasyoun/Uprava/blob/main/METADOCS_INDEX.md) (private hub) |
+
+## Consolidation verdict (H1245 pass 3, 18-07-2026)
+
+Checked for content duplicated between this manual and
+[README.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/README.md),
+[CLAUDE.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/CLAUDE.md), and
+[readme_new_dict_addition.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/readme_new_dict_addition.md):
+**nothing to fold.** The three-doc division declared at the top of the manual is real
+in practice — README is the intro + taxonomy entry point, CLAUDE.md holds only the
+issue taxonomy, and the new-dict flow keeps execution detail in
+`readme_new_dict_addition.md` with the manual as the map. No pointer stubs were needed.
 
 ## Known limitations
 
-- Written from source-and-docs evidence; the sibling `cologne/csl-orig` umbrella
-  layout was not present in the authoring checkout, so `redo_*` commands are
-  transcribed from the scripts, not re-executed.
+- Written from source-and-docs evidence; the `cologne/` umbrella layout was not
+  present in the authoring checkout. Since the 18-07-2026 refresh (H1245) the
+  path-parameterized engines and repo-root tools ARE verified live; the `redo_*` /
+  `install_local.sh` / `download2*.sh` **drivers** remain transcribed, not re-executed
+  (umbrella layout + production server still absent), as are the Python-2-only
+  scripts (no `python2` on the verifying host).
 - The `issues/` section is deliberately structural (270 archival files are not
   enumerated).
 - Load-bearing verdicts mirror the cleanup taxonomy as of 464-row generation
@@ -134,5 +165,6 @@ commands or directory map are stale.
 |---|---|---|
 | 11-07-2026 | Initial version (H506): cheat-sheet, data-flow, 14 directory walkthroughs, new-dict flow, load-bearing verdicts, symptom table, glossary, maintainer appendix | Fable 5 (`claude-fable-5`) |
 | 11-07-2026 | template v2 backfill (H663) | Sonnet 5 (`claude-sonnet-5`) |
+| 18-07-2026 | H1245 estate refresh: fact-check recounts (issues/ 265 not 270; catall 36 not 34; stardict redo 36 not 37; eascii output format), executed worked example for `updateByLine.py`, engine-verification pattern + DeprecationWarning symptom row, `LAST_VERIFIED` block + backlog reconcile, consolidation verdict (no fold) | Fable 5 (`claude-fable-5`) |
 
 _Dr. Mārcis Gasūns_


### PR DESCRIPTION
One documentation-only PR (no code, data, or pipeline changes) — the COLOGNE leg of the org-wide big-manuals estate refresh, handoff [H1245](https://github.com/gasyoun/Uprava/blob/main/handoffs/H1245-Fable_multi_big-manuals-estate-refresh-umbrella_18.07.26.md).

Drift since the manual's 11-07-2026 authoring was tiny (3 commits, none touching tooling), so the budget went to **verification depth** rather than refresh churn:

## Pass 1 — fact-check against the tree (commit 1)
- `issues/` is **265 files, not 270** (248 `archive-no-refactor` + 17 `promote-or-sunset` per the taxonomy CSV).
- `xmltag/catall.sh` iterates **36 codes, not 34** (the 8 codes it lacks vs `redo_all.sh` now named).
- `stardict/redo.sh` is **36 codes, not 37**.
- eascii output-format example corrected to the real `\uNNNN` parenthetical form.
- iast section: what the three checks actually print, verified live (84 mappings, all clean; the committed `slp1_iast.txt` is in sync with the XMLs).
- Taxonomy CSV row count given an as-of stamp (committed 464; a fresh 18-07 verification run classifies 482 — diff discarded per the manual's own trap note).

## Pass 2 — deepen with executed examples (commit 2)
- `updateByLine.py` worked example with real output — both the apply path and the stop-on-mismatch safety property.
- New Environment note: the Python engines are path-parameterized and verifiable against any `csl-orig` checkout without the `cologne/` umbrella (real outputs quoted for `xmltag.py`, `ea.py`, `chgtag.py`).
- Symptom-table row for the cosmetic Python 3.13+ `codecs.open()` DeprecationWarning.

## Pass 3 — consolidation verdict (no commit)
Nothing to fold between the manual, [README.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/README.md), [CLAUDE.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/CLAUDE.md) and [readme_new_dict_addition.md](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/readme_new_dict_addition.md) — the declared three-doc division of labor is real. Verdict recorded in the metadoc.

## Metadoc + bookkeeping (commit 3)
- `docs/TOOLING_MANUAL.meta.md`: `LAST_VERIFIED` block (**6 commands spot-run**), backlog reconciled (items 2 + 5 closed, item 1 narrowed to umbrella-layout drivers + py2-only scripts), revision row.
- `.ai_state.md`: stale 07-07 WIP row cleared (the README rewrite it referenced landed 11-07).
- New `CHANGELOG.md` with an Unreleased entry. No release cut — this repo has no tag/release convention; first release is a maintainer call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)